### PR TITLE
mysql improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ go:
   - 1.9
   - 1.8
 sudo: false
+services:
+  - mysql
 
 env:
     CI_SERVICE=travis-ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ cache:
     - ${GOPATH}/src/golang.org/x
 go:
   - tip
+  - 1.10.x
   - 1.9
   - 1.8
 sudo: false

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -8,6 +8,12 @@
   version = "v1.1.0"
 
 [[projects]]
+  name = "github.com/go-sql-driver/mysql"
+  packages = ["."]
+  revision = "d523deb1b23d913de5bdada721a6071e71283618"
+  version = "v1.4.0"
+
+[[projects]]
   name = "github.com/pmezard/go-difflib"
   packages = ["difflib"]
   revision = "792786c7400a136282c1664665ae0a8db921c6c2"
@@ -19,9 +25,15 @@
   revision = "69483b4bd14f5845b5a1e55bca19e954e827f1d0"
   version = "v1.1.4"
 
+[[projects]]
+  name = "google.golang.org/appengine"
+  packages = ["cloudsql"]
+  revision = "b1f26356af11148e710935ed1ac8a7f5702c7612"
+  version = "v1.1.0"
+
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "51090081ffb338d83991389328cb66b95b3eb8c572ed28a231da4e46f1bc6358"
+  inputs-digest = "861a272544df2cc57045adec7677e2ddf61a68d28cc2c513aeff5dc322804fff"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -24,3 +24,7 @@
 [[constraint]]
   name = "github.com/stretchr/testify"
   version = "1.1.4"
+
+[[constraint]]
+  name = "github.com/go-sql-driver/mysql"
+  version = "1.4.0"

--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@
 
 Library that uses convention to read configuration parameters from the environment.
 
-
 ## environment variables
 
 ### app:MySQL
@@ -20,9 +19,8 @@ Library that uses convention to read configuration parameters from the environme
 - **MYSQL_PORT**: port (default: `3306`).
 - **MYSQL_USER**: user name.
 
-
+- [github.com/go-sql-driver/mysql](https://github.com/go-sql-driver/mysql)
 - [hub.docker.com/_/mysql](https://hub.docker.com/_/mysql/)
-
 
 ### app:PostgreSQL
 
@@ -39,7 +37,6 @@ Library that uses convention to read configuration parameters from the environme
 - **REDIS_PORT**: port (default: `6379`).
 - **REDIS_HOST**: host.
 
-
 ### app:Resque
 
 - **RESQUE_COUNT**: number of Resque workers to be spawned (default: `1`).
@@ -47,7 +44,6 @@ Library that uses convention to read configuration parameters from the environme
 - **RESQUE_PIDFILE**: PID file location..
 - **RESQUE_QUEUE**: name of a single Resque queue.
 - **RESQUE_QUEUES**: list of Resque queue names (default: `*`).
-
 
 ### cloud:AWS
 
@@ -63,9 +59,7 @@ Library that uses convention to read configuration parameters from the environme
 - **AWS_SESSION_TOKEN**: temporary session token (default: ``).
 - **AWS_SHARED_CREDENTIALS_FILE**: path to the file where access keys are stored.
 
-
 - [AWS Documentation » AWS Command Line Interface » User Guide » Configuring the AWS CLI » Environment Variables](http://docs.aws.amazon.com/cli/latest/userguide/cli-environment.html)
-
 
 [license]:  https://raw.githubusercontent.com/steenzout/go-env/master/LICENSE   "Apache License 2.0"
 [project]:  https://www.openhub.net/p/go-steenzout-env/    "OpenHub project page"

--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ Library that uses convention to read configuration parameters from the environme
 ### app:MySQL
 
 - **MYSQL_DB**: name of the MySQL database.
-- **MYSQL_HOST**: host.
+- **MYSQL_HOST**: host (default: `/var/run/mysqld/mysqld.sock`).
 - **MYSQL_PASSWORD**: password (default: `''`)
 - **MYSQL_PORT**: port (default: `3306`).
-- **MYSQL_PROTOCOL**: protocol to establish connection (default: `tcp`)
+- **MYSQL_PROTOCOL**: protocol to establish connection (default: `unix`)
 - **MYSQL_ROOT_PASSWORD**: root password (default: `''`)
 - **MYSQL_USER**: user name.
 

--- a/README.md
+++ b/README.md
@@ -15,8 +15,10 @@ Library that uses convention to read configuration parameters from the environme
 
 - **MYSQL_DB**: name of the MySQL database.
 - **MYSQL_HOST**: host.
-- **MYSQL_PASSWORD**: password.
+- **MYSQL_PASSWORD**: password (default: `''`)
 - **MYSQL_PORT**: port (default: `3306`).
+- **MYSQL_PROTOCOL**: protocol to establish connection (default: `tcp`)
+- **MYSQL_ROOT_PASSWORD**: root password (default: `''`)
 - **MYSQL_USER**: user name.
 
 - [github.com/go-sql-driver/mysql](https://github.com/go-sql-driver/mysql)

--- a/aws.go
+++ b/aws.go
@@ -1,7 +1,7 @@
 package env
 
 //
-// Copyright 2017 Pedro Salgado
+// Copyright 2017-2018 Pedro Salgado
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/aws_test.go
+++ b/aws_test.go
@@ -1,7 +1,7 @@
 package env_test
 
 //
-// Copyright 2017 Pedro Salgado
+// Copyright 2017-2018 Pedro Salgado
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/doc.go
+++ b/doc.go
@@ -1,6 +1,6 @@
 // Package env uses a convention to read configuration parameters from the environment.
 //
-// Copyright 2017 Pedro Salgado
+// Copyright 2017-2018 Pedro Salgado
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '3.1'
+
+services:
+
+  db_mysql:
+    image: mysql:5.6
+    restart: always
+    ports:
+      - '3306:3306'
+    environment:
+      MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'

--- a/mandatory.go
+++ b/mandatory.go
@@ -1,7 +1,7 @@
 package env
 
 //
-// Copyright 2017 Pedro Salgado
+// Copyright 2017-2018 Pedro Salgado
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/mandatory_test.go
+++ b/mandatory_test.go
@@ -1,7 +1,7 @@
 package env_test
 
 //
-// Copyright 2017 Pedro Salgado
+// Copyright 2017-2018 Pedro Salgado
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/mysql.go
+++ b/mysql.go
@@ -58,5 +58,5 @@ func GetMySQLUser() string {
 
 // GetMySQLRootPassword returns the MySQL root password.
 func GetMySQLRootPassword() string {
-	return GetString(EnvMySQLRootPassword)
+	return GetOptionalString(EnvMySQLRootPassword, "")
 }

--- a/mysql.go
+++ b/mysql.go
@@ -1,5 +1,10 @@
 package env
 
+import (
+	"database/sql"
+	"fmt"
+)
+
 //
 // Copyright 2017-2018 Pedro Salgado
 //
@@ -32,6 +37,31 @@ const (
 	// EnvMySQLUser name of the environment variable that contains the MySQL user.
 	EnvMySQLUser = "MYSQL_USER"
 )
+
+// GetMySQLConnection attempts to setup the database connection based on the environment.
+func GetMySQLConnection() (*sql.DB, error) {
+	// [username[:password]@][protocol[(address)]]/dbname[?param1=value1&...&paramN=valueN]
+	db, err := sql.Open(
+		"mysql",
+		fmt.Sprintf(
+			"%s:%s@%s(%s)/%s",
+			GetMySQLUser(),
+			GetMySQLPassword(),
+			GetMySQLProtocol(),
+			GetMySQLHost(),
+			GetMySQLDatabase(),
+		))
+	if err != nil {
+		return nil, err
+	}
+
+	err = db.Ping()
+	if err != nil {
+		return nil, err
+	}
+
+	return db, nil
+}
 
 // GetMySQLDatabase returns the MySQL database.
 func GetMySQLDatabase() string {

--- a/mysql.go
+++ b/mysql.go
@@ -1,7 +1,7 @@
 package env
 
 //
-// Copyright 2017 Pedro Salgado
+// Copyright 2017-2018 Pedro Salgado
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/mysql.go
+++ b/mysql.go
@@ -70,7 +70,7 @@ func GetMySQLDatabase() string {
 
 // GetMySQLHost returns the MySQL host.
 func GetMySQLHost() string {
-	return GetString(EnvMySQLHost)
+	return GetOptionalString(EnvMySQLHost, "/var/run/mysqld/mysqld.sock")
 }
 
 // GetMySQLPassword returns the MySQL user password.
@@ -80,7 +80,7 @@ func GetMySQLPassword() string {
 
 // GetMySQLProtocol returns the protocol to use when connecting to MySQL (default: tcp).
 func GetMySQLProtocol() string {
-	return GetOptionalString(EnvMySQLProtocol, "tcp")
+	return GetOptionalString(EnvMySQLProtocol, "unix")
 }
 
 // GetMySQLPort returns the MySQL port.

--- a/mysql.go
+++ b/mysql.go
@@ -25,6 +25,8 @@ const (
 	EnvMySQLPassword = "MYSQL_PASSWORD"
 	// EnvMySQLPort name of the environment variable that contains the MySQL port.
 	EnvMySQLPort = "MYSQL_PORT"
+	// EnvMySQLProtocol name of the environment variable that contains the protocol to be used when connecting to MySQL.
+	EnvMySQLProtocol = "MYSQL_PROTOCOL"
 	// EnvMySQLRootPassword name of the environment variable that contains the MySQL root's password.
 	EnvMySQLRootPassword = "MYSQL_ROOT_PASSWORD"
 	// EnvMySQLUser name of the environment variable that contains the MySQL user.
@@ -44,6 +46,11 @@ func GetMySQLHost() string {
 // GetMySQLPassword returns the MySQL user password.
 func GetMySQLPassword() string {
 	return GetOptionalString(EnvMySQLPassword, "")
+}
+
+// GetMySQLProtocol returns the protocol to use when connecting to MySQL (default: tcp).
+func GetMySQLProtocol() string {
+	return GetOptionalString(EnvMySQLProtocol, "tcp")
 }
 
 // GetMySQLPort returns the MySQL port.

--- a/mysql.go
+++ b/mysql.go
@@ -43,7 +43,7 @@ func GetMySQLHost() string {
 
 // GetMySQLPassword returns the MySQL user password.
 func GetMySQLPassword() string {
-	return GetString(EnvMySQLPassword)
+	return GetOptionalString(EnvMySQLPassword, "")
 }
 
 // GetMySQLPort returns the MySQL port.

--- a/mysql_test.go
+++ b/mysql_test.go
@@ -57,5 +57,7 @@ func (s MySQLTestSuite) TestGetMySQL() {
 
 // TestGetMySQL check default value behavior of GetMySQL*().
 func (s ClearEnvSuite) TestGetMySQL() {
+	s.Equal("", env.GetMySQLPassword())
 	s.Equal(3306, env.GetMySQLPort())
+	s.Equal("", env.GetMySQLRootPassword())
 }

--- a/mysql_test.go
+++ b/mysql_test.go
@@ -1,7 +1,7 @@
 package env_test
 
 //
-// Copyright 2017 Pedro Salgado
+// Copyright 2017-2018 Pedro Salgado
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/mysql_test.go
+++ b/mysql_test.go
@@ -19,6 +19,8 @@ package env_test
 import (
 	"os"
 
+	_ "github.com/go-sql-driver/mysql"
+
 	"github.com/stretchr/testify/suite"
 
 	"github.com/steenzout/go-env"
@@ -29,17 +31,6 @@ type MySQLTestSuite struct {
 	suite.Suite
 }
 
-// SetupTest sets test environment variables.
-func (s MySQLTestSuite) SetupTest() {
-	os.Clearenv()
-	os.Setenv(env.EnvMySQLDatabase, "db")
-	os.Setenv(env.EnvMySQLHost, "localhost")
-	os.Setenv(env.EnvMySQLPort, "3306")
-	os.Setenv(env.EnvMySQLPassword, "secret")
-	os.Setenv(env.EnvMySQLRootPassword, "bigsecret")
-	os.Setenv(env.EnvMySQLUser, "user")
-}
-
 // TearDownTest clears all environment variables.
 func (s MySQLTestSuite) TearDownTest() {
 	os.Clearenv()
@@ -47,17 +38,64 @@ func (s MySQLTestSuite) TearDownTest() {
 
 // Test check behavior of GetMySQL*() functions.
 func (s MySQLTestSuite) TestGetMySQL() {
-	s.Equal("db", env.GetMySQLDatabase())
-	s.Equal("localhost", env.GetMySQLHost())
-	s.Equal("secret", env.GetMySQLPassword())
+	setUp := func() {
+		os.Setenv(env.EnvMySQLDatabase, "test")
+		os.Setenv(env.EnvMySQLHost, "example.com")
+		os.Setenv(env.EnvMySQLPort, "3306")
+		os.Setenv(env.EnvMySQLProtocol, "tcp")
+		os.Setenv(env.EnvMySQLPassword, "secret1")
+		os.Setenv(env.EnvMySQLRootPassword, "secret2")
+		os.Setenv(env.EnvMySQLUser, "travis")
+	}
+	setUp()
+
+	s.Equal("test", env.GetMySQLDatabase())
+	s.Equal("example.com", env.GetMySQLHost())
+	s.Equal("secret1", env.GetMySQLPassword())
 	s.Equal(3306, env.GetMySQLPort())
-	s.Equal("bigsecret", env.GetMySQLRootPassword())
-	s.Equal("user", env.GetMySQLUser())
+	s.Equal("secret2", env.GetMySQLRootPassword())
+	s.Equal("travis", env.GetMySQLUser())
+}
+
+// TestGetMySQLConnection check behavior of GetMySQLConnection().
+func (s MySQLTestSuite) TestGetMySQLConnection() {
+	setUp := func() {
+		os.Setenv(env.EnvMySQLDatabase, "mysql")
+		os.Setenv(env.EnvMySQLHost, "127.0.0.1")
+		os.Setenv(env.EnvMySQLPort, "3306")
+		os.Setenv(env.EnvMySQLProtocol, "tcp")
+		os.Setenv(env.EnvMySQLPassword, "")
+		os.Setenv(env.EnvMySQLRootPassword, "")
+		os.Setenv(env.EnvMySQLUser, "root")
+	}
+	setUp()
+
+	db, err := env.GetMySQLConnection()
+	if s.Nil(err) && s.NotNil(db) {
+		s.Nil(db.Ping())
+	}
+}
+
+// TestWrongCredentials check behavior when wrong credentials are passed to GetMySQLConnection().
+func (s MySQLTestSuite) TestWrongCredentials() {
+	os.Setenv(env.EnvMySQLDatabase, "mysql")
+	os.Setenv(env.EnvMySQLHost, "127.0.0.1")
+	os.Setenv(env.EnvMySQLPort, "3306")
+	os.Setenv(env.EnvMySQLProtocol, "tcp")
+	os.Setenv(env.EnvMySQLPassword, "bad")
+	os.Setenv(env.EnvMySQLRootPassword, "bad")
+	os.Setenv(env.EnvMySQLUser, "root")
+
+	db, err := env.GetMySQLConnection()
+	if s.NotNil(err) {
+		s.Nil(db)
+	}
 }
 
 // TestGetMySQL check default value behavior of GetMySQL*().
 func (s ClearEnvSuite) TestGetMySQL() {
 	s.Equal("", env.GetMySQLPassword())
 	s.Equal(3306, env.GetMySQLPort())
+	s.Equal("tcp", env.GetMySQLProtocol())
 	s.Equal("", env.GetMySQLRootPassword())
 }

--- a/mysql_test.go
+++ b/mysql_test.go
@@ -94,8 +94,9 @@ func (s MySQLTestSuite) TestWrongCredentials() {
 
 // TestGetMySQL check default value behavior of GetMySQL*().
 func (s ClearEnvSuite) TestGetMySQL() {
+	s.Equal("/var/run/mysqld/mysqld.sock", env.GetMySQLHost())
 	s.Equal("", env.GetMySQLPassword())
 	s.Equal(3306, env.GetMySQLPort())
-	s.Equal("tcp", env.GetMySQLProtocol())
+	s.Equal("unix", env.GetMySQLProtocol())
 	s.Equal("", env.GetMySQLRootPassword())
 }

--- a/optional.go
+++ b/optional.go
@@ -1,7 +1,7 @@
 package env
 
 //
-// Copyright 2017 Pedro Salgado
+// Copyright 2017-2018 Pedro Salgado
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/optional_test.go
+++ b/optional_test.go
@@ -1,7 +1,7 @@
 package env_test
 
 //
-// Copyright 2017 Pedro Salgado
+// Copyright 2017-2018 Pedro Salgado
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/package_test.go
+++ b/package_test.go
@@ -1,7 +1,7 @@
 package env_test
 
 //
-// Copyright 2017 Pedro Salgado
+// Copyright 2017-2018 Pedro Salgado
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/postgresql.go
+++ b/postgresql.go
@@ -1,7 +1,7 @@
 package env
 
 //
-// Copyright 2017 Pedro Salgado
+// Copyright 2017-2018 Pedro Salgado
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/postgresql_test.go
+++ b/postgresql_test.go
@@ -1,7 +1,7 @@
 package env_test
 
 //
-// Copyright 2017 Pedro Salgado
+// Copyright 2017-2018 Pedro Salgado
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/redis.go
+++ b/redis.go
@@ -1,7 +1,7 @@
 package env
 
 //
-// Copyright 2017 Pedro Salgado
+// Copyright 2017-2018 Pedro Salgado
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/redis_test.go
+++ b/redis_test.go
@@ -1,7 +1,7 @@
 package env_test
 
 //
-// Copyright 2017 Pedro Salgado
+// Copyright 2017-2018 Pedro Salgado
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/resque.go
+++ b/resque.go
@@ -1,7 +1,7 @@
 package env
 
 //
-// Copyright 2017 Pedro Salgado
+// Copyright 2017-2018 Pedro Salgado
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/resque_test.go
+++ b/resque_test.go
@@ -1,7 +1,7 @@
 package env_test
 
 //
-// Copyright 2017 Pedro Salgado
+// Copyright 2017-2018 Pedro Salgado
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
- test against Go 1.10.x
- `mysql.go`
  - added `GetMySQLConnection()`
  - added `MYSQL_PROTOCOL` environment variable
  - added `GetMySQLProtocol()`
  - `GetMySQLHost()` now has a default (`unix`)
  - `GetMySQLPassword()` now has a default (`''`)
  - `GetMySQLRootPassword()` now has a default (`''`)
  - default behavior for MySQL is now inline with the mysql command-line interface
