### PR TITLE
4.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ go:
   - tip
   - 1.10.x
   - 1.9
-  - 1.8
 sudo: false
 services:
   - mysql

--- a/influxdb.go
+++ b/influxdb.go
@@ -22,6 +22,8 @@ const (
 	EnvInfluxDBDatabase = "INFLUXDB_DB"
 	// EnvInfluxDBHost name of the environment variable that contains the InfluxDB host.
 	EnvInfluxDBHost = "INFLUXDB_HOST"
+	// EnvInfluxDBProtocol name of the environment variable that contains the protocol to be used when connecting to InfluxDB.
+	EnvInfluxDBProtocol = "INFLUXDB_PROTOCOL"
 
 	// EnvInfluxDBPort name of the environment variable that contains the InfluxDB HTTP API port.
 	EnvInfluxDBPort = "INFLUXDB_PORT"
@@ -103,6 +105,11 @@ func GetInfluxDBUser() string {
 // GetInfluxDBPassword returns the InfluxDB database read/write account password.
 func GetInfluxDBPassword() string {
 	return GetString(EnvInfluxDBPassword)
+}
+
+// GetInfluxDBProtocol returns the protocol to use when connecting to InfluxDB (default: http).
+func GetInfluxDBProtocol() string {
+	return GetOptionalString(EnvInfluxDBProtocol, "http")
 }
 
 // GetInfluxDBReadUser returns the InfluxDB database read account.

--- a/influxdb.go
+++ b/influxdb.go
@@ -26,6 +26,7 @@ const (
 	// EnvInfluxDBPort name of the environment variable that contains the InfluxDB HTTP API port.
 	EnvInfluxDBPort = "INFLUXDB_PORT"
 	// EnvInfluxDBAdminPort name of the environment variable that contains the InfluxDB administrator interface port.
+	// The administrator interface is deprecated as of 1.1.0 and will be removed in 1.3.0.
 	EnvInfluxDBAdminPort = "INFLUXDB_ADMIN_PORT"
 	// EnvInfluxDBGraphitePort name of the environment variable that contains the Graphite support port.
 	EnvInfluxDBGraphitePort = "INFLUXDB_GRAPHITE_PORT"
@@ -70,18 +71,18 @@ func GetInfluxDBHost() string {
 }
 
 // GetInfluxDBPort returns the InfluxDB HTTP API port.
-func GetInfluxDBPort() string {
-	return GetString(EnvInfluxDBPort)
+func GetInfluxDBPort() int {
+	return GetOptionalInt(EnvInfluxDBPort, 8086)
 }
 
 // GetInfluxDBAdminPort returns the InfluxDB administrator interface port.
-func GetInfluxDBAdminPort() string {
-	return GetString(EnvInfluxDBAdminPort)
+func GetInfluxDBAdminPort() int {
+	return GetOptionalInt(EnvInfluxDBAdminPort, 8083)
 }
 
 // GetInfluxDBGraphitePort returns the Graphite support port.
-func GetInfluxDBGraphitePort() string {
-	return GetString(EnvInfluxDBGraphitePort)
+func GetInfluxDBGraphitePort() int {
+	return GetOptionalInt(EnvInfluxDBGraphitePort, 2003)
 }
 
 // GetInfluxDBAdminUser returns the InfluxDB administrator account.

--- a/influxdb_test.go
+++ b/influxdb_test.go
@@ -39,6 +39,7 @@ func (s InfluxDBTestSuite) TestGetInfluxDB() {
 	setUp := func() {
 		os.Setenv(env.EnvInfluxDBDatabase, "test")
 		os.Setenv(env.EnvInfluxDBHost, "example.com")
+		os.Setenv(env.EnvInfluxDBProtocol, "https")
 		os.Setenv(env.EnvInfluxDBPort, "1234")
 		os.Setenv(env.EnvInfluxDBAdminPort, "1235")
 		os.Setenv(env.EnvInfluxDBGraphitePort, "1236")
@@ -55,6 +56,7 @@ func (s InfluxDBTestSuite) TestGetInfluxDB() {
 
 	s.Equal("test", env.GetInfluxDBDatabase())
 	s.Equal("example.com", env.GetInfluxDBHost())
+	s.Equal("https", env.GetInfluxDBProtocol())
 	s.Equal(1234, env.GetInfluxDBPort())
 	s.Equal(1235, env.GetInfluxDBAdminPort)
 	s.Equal(1236, env.GetInfluxDBGraphitePort())
@@ -70,6 +72,7 @@ func (s InfluxDBTestSuite) TestGetInfluxDB() {
 
 // TestGetInfluxDBDefaultValues check default value behavior of GetInfluxDB*().
 func (s ClearEnvSuite) TestGetInfluxDBDefaultValues() {
+	s.Equal("http", env.GetInfluxDBProtocol())
 	s.Equal(8086, env.GetInfluxDBPort())
 	s.Equal(8083, env.GetInfluxDBAdminPort())
 	s.Equal(2003, env.GetInfluxDBGraphitePort())

--- a/influxdb_test.go
+++ b/influxdb_test.go
@@ -40,6 +40,8 @@ func (s InfluxDBTestSuite) TestGetInfluxDB() {
 		os.Setenv(env.EnvInfluxDBDatabase, "test")
 		os.Setenv(env.EnvInfluxDBHost, "example.com")
 		os.Setenv(env.EnvInfluxDBPort, "1234")
+		os.Setenv(env.EnvInfluxDBAdminPort, "1235")
+		os.Setenv(env.EnvInfluxDBGraphitePort, "1236")
 		os.Setenv(env.EnvInfluxDBAdminUser, "root")
 		os.Setenv(env.EnvInfluxDBAdminPassword, "secret")
 		os.Setenv(env.EnvInfluxDBUser, "usr")
@@ -53,7 +55,9 @@ func (s InfluxDBTestSuite) TestGetInfluxDB() {
 
 	s.Equal("test", env.GetInfluxDBDatabase())
 	s.Equal("example.com", env.GetInfluxDBHost())
-	s.Equal("1234", env.GetInfluxDBPort())
+	s.Equal(1234, env.GetInfluxDBPort())
+	s.Equal(1235, env.GetInfluxDBAdminPort)
+	s.Equal(1236, env.GetInfluxDBGraphitePort())
 	s.Equal("root", env.GetInfluxDBAdminUser())
 	s.Equal("secret", env.GetInfluxDBAdminPassword())
 	s.Equal("usr", env.GetInfluxDBUser())
@@ -62,4 +66,11 @@ func (s InfluxDBTestSuite) TestGetInfluxDB() {
 	s.Equal("only", env.GetInfluxDBReadPassword())
 	s.Equal("writer", env.GetInfluxDBWriteUser())
 	s.Equal("always", env.GetInfluxDBWritePassword())
+}
+
+// TestGetInfluxDBDefaultValues check default value behavior of GetInfluxDB*().
+func (s ClearEnvSuite) TestGetInfluxDBDefaultValues() {
+	s.Equal(8086, env.GetInfluxDBPort())
+	s.Equal(8083, env.GetInfluxDBAdminPort())
+	s.Equal(2003, env.GetInfluxDBGraphitePort())
 }

--- a/mysql_test.go
+++ b/mysql_test.go
@@ -104,8 +104,8 @@ func (s MySQLTestSuite) TestWrongCredentials() {
 	}
 }
 
-// TestGetMySQL check default value behavior of GetMySQL*().
-func (s ClearEnvSuite) TestGetMySQL() {
+// TestGetMySQLDefaultValues check default value behavior of GetMySQL*().
+func (s ClearEnvSuite) TestGetMySQLDefaultValues() {
 	s.Equal("/var/run/mysqld/mysqld.sock", env.GetMySQLHost())
 	s.Equal("", env.GetMySQLPassword())
 	s.Equal(3306, env.GetMySQLPort())


### PR DESCRIPTION
- `influxdb`
  - added `GetInfluxDBProtocol()`
  - changed signature of `GetInfluxDB*Port()` functions
- removed testing for Go 1.8
